### PR TITLE
Fall back to python if there is no python2, like e.g. on Windows

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -1,4 +1,23 @@
-#! /usr/bin/python2
+#! /bin/sh
+# -*- mode: python; coding: utf-8 -*-
+
+# This file is used as both a shell script and as a Python script.
+
+""":"
+# This part is run by the shell.  It looks for an appropriate Python
+# interpreter then uses it to re-exec this script.
+
+path=$(which python2 || which python)
+if [ -x "$path" ]
+then
+  PYTHON=$path
+else
+  echo 1>&2 "No usable Python interpreter was found!"
+  exit 1
+fi
+
+exec $PYTHON "$0" "$@"
+" """
 
 # Copyright (c) 2013 Michael Haggerty
 #


### PR DESCRIPTION
As msysgit does not ship with Python, a natural choice is to install
vanilla Python 2 from www.python.org on Windows. That installation does
not come with a "python2" executable, so allow to fall back to "python".
Also, on Windows the vanilla Python installation will usually not be at
/usr/bin, so search the PATH instead.

Uses the method described at:
http://softwareswirl.blogspot.com/2011/06/starting-python-script-intelligently.html
