### PR TITLE
Support Python 3

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -1,23 +1,5 @@
-#! /bin/sh
+#!/usr/bin/env python
 # -*- mode: python; coding: utf-8 -*-
-
-# This file is used as both a shell script and as a Python script.
-
-""":"
-# This part is run by the shell.  It looks for an appropriate Python
-# interpreter then uses it to re-exec this script.
-
-path=$(which python2 || which python)
-if [ -x "$path" ]
-then
-  PYTHON=$path
-else
-  echo 1>&2 "No usable Python interpreter was found!"
-  exit 1
-fi
-
-exec $PYTHON "$0" "$@"
-" """
 
 # Copyright (c) 2013 Michael Haggerty
 #
@@ -36,7 +18,6 @@ exec $PYTHON "$0" "$@"
 
 # Run "git when-merged --help for the documentation.
 
-__doc__ = \
 """Find when a commit was merged into one or more branches.
 
 Find the merge commit that brought COMMIT into the specified


### PR DESCRIPTION
I wondered how hard it would be to make `git when-merged` support Python 3 and the answer turned out to be "not very" and I don't think it makes the code particularly messy, so here's the pull request :smiley:

This does mean that support for Python 2.5 has to be dropped (it doesn't support the "`as`" syntax in `except` blocks), so feel free to just close this if you'd rather keep support for that.
