### PR TITLE
Add a link to the github project as a comment

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -17,6 +17,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 
 # Run "git when-merged --help for the documentation.
+# See https://github.com/mhagger/git-when-merged for the project.
 
 """Find when a commit was merged into one or more branches.
 


### PR DESCRIPTION
Suggestion to add a comment linking to the github project, so once it is deployed somewhere a user can know where it came from