### PR TITLE
Add a `--log`/`-l` option

### DIFF
--- a/README
+++ b/README
@@ -28,6 +28,7 @@ Options:
                         characters (or more if needed to avoid ambiguity).
                         See also whenmerged.abbrev below under CONFIGURATION.
   --no-abbrev           Do not abbreviate commit SHA1s.
+  -l, --log             Show the log for the merge commit.
   -d, --diff            Show the diff for the merge commit.
   -v, --visualize       Visualize the merge commit using gitk.
 

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -420,7 +420,7 @@ def main(args):
 
         if merge:
             if options.diff:
-                subprocess.check_call(['git', 'show', merge])
+                subprocess.check_call(['git', '--no-pager', 'show', merge])
 
             if options.visualize:
                 subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -49,7 +49,8 @@ Examples:
   git when-merged 0a1b -n releases         # Use whenmerged.releases.pattern
   git when-merged 0a1b -s                  # Use whenmerged.default.pattern
 
-  git when-merged 0a1b -d feature-1        # Show diff for each merge commit
+  git when-merged 0a1b -l feature-1        # Show log for the merge commit
+  git when-merged 0a1b -d feature-1        # Show diff for the merge commit
   git when-merged 0a1b -v feature-1        # Display merge commit in gitk
 
 Configuration:

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -353,6 +353,10 @@ def main(args):
         help='Do not abbreviate commit SHA1s.',
         )
     parser.add_option(
+        '--log', '-l', action='store_true', default=False,
+        help='Show the log for the merge commit.',
+        )
+    parser.add_option(
         '--diff', '-d', action='store_true', default=False,
         help='Show the diff for the merge commit.',
         )
@@ -419,6 +423,9 @@ def main(args):
             continue
 
         if merge:
+            if options.log:
+                subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
+
             if options.diff:
                 subprocess.check_call(['git', '--no-pager', 'show', merge])
 


### PR DESCRIPTION
Honestly, the diff for a merge commit isn't often very useful. But the author, log message, and timestamp *are*. So add a `--log`/`-l` option that shows the `git log` for the commit without the diff.
