### PR TITLE
Add a `--recursive`/`-r` option

### DIFF
--- a/README
+++ b/README
@@ -31,6 +31,7 @@ Options:
                         the configured pattern(s) with the given name (see
                         whenmerged.<name>.pattern below under CONFIGURATION).
   -s, --default         Shorthand for "--name=default".
+  -r, --recursive       Follow merges back recursively.
   --abbrev=N            Abbreviate commit SHA1s to the specified number of
                         characters (or more if needed to avoid ambiguity).
                         See also whenmerged.abbrev below under CONFIGURATION.
@@ -56,6 +57,9 @@ Examples:
   git when-merged 0a1b -p feature-[0-9]+   # Specify branches by regex
   git when-merged 0a1b -n releases         # Use whenmerged.releases.pattern
   git when-merged 0a1b -s                  # Use whenmerged.default.pattern
+
+  git when-merged 0a1b -r feature-1        # If merged indirectly, show all
+                                           # merges involved.
 
   git when-merged 0a1b -d feature-1        # Show diff for each merge commit
   git when-merged 0a1b -v feature-1        # Display merge commit in gitk

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -214,6 +214,13 @@ def rev_parse(arg, abbrev=None):
 
 
 def rev_list(*args):
+    """Iterate over (commit, [parent,...]) for the selected commits.
+
+    args are passed as arguments to "git rev-list" to select which
+    commits should be iterated over.
+
+    """
+
     process = subprocess.Popen(
         ['git', 'rev-list'] + list(args) + ['--'],
         stdout=subprocess.PIPE,

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -275,9 +275,24 @@ class CommitGraph:
             commit = parents[0]
 
 
-FORMAT = '%(refname)-38s %(msg)s\n'
+class MergeNotFoundError(Exception):
+    def __init__(self, refname):
+        self.refname = refname
 
-def find_merge(commit, branch, abbrev):
+
+class InvalidCommitError(MergeNotFoundError):
+    msg = 'Is not a valid commit!'
+
+
+class DoesNotContainCommitError(MergeNotFoundError):
+    msg = 'Does not contain commit.'
+
+
+class DirectlyOnBranchError(MergeNotFoundError):
+    msg = 'Commit is directly on this branch.'
+
+
+def find_merge(commit, branch):
     """Return the SHA1 of the commit that merged commit into branch.
 
     It is assumed that content is always merged in via the second or
@@ -285,16 +300,14 @@ def find_merge(commit, branch, abbrev):
 
     try:
         branch_sha1 = rev_parse(branch)
-    except Failure as e:
-        sys.stdout.write(FORMAT % dict(refname=branch, msg='Is not a valid commit!'))
-        return None
+    except Failure:
+        raise InvalidCommitError(branch)
 
     commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit, branch_sha1))
     branch_commits = list(commit_graph.first_parent_path(branch_sha1))
 
     if not branch_commits:
-        sys.stdout.write(FORMAT % dict(refname=branch, msg='Does not contain commit.'))
-        return None
+        raise DoesNotContainCommitError(branch)
 
     # The last entry in branch_commits is the one that merged in
     # commit.
@@ -302,14 +315,7 @@ def find_merge(commit, branch, abbrev):
     parents = commit_graph[last]
 
     if parents[0] == commit:
-        sys.stdout.write(FORMAT % dict(refname=branch, msg='Commit is directly on this branch.'))
-        return None
-
-    if abbrev is not None:
-        msg = rev_parse(last, abbrev=abbrev)
-    else:
-        msg = last
-    sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
+        raise DirectlyOnBranchError(branch)
 
     return last
 
@@ -349,6 +355,9 @@ def get_full_name(branch):
     # leave it in its original form:
     rev_parse(branch)
     return branch
+
+
+FORMAT = '%(refname)-38s %(msg)s\n'
 
 
 def main(args):
@@ -468,20 +477,28 @@ def main(args):
 
     for branch in sorted(branches):
         try:
-            merge = find_merge(commit, branch, options.abbrev)
+            merge = find_merge(commit, branch)
+        except MergeNotFoundError as e:
+            sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+            continue
         except Failure as e:
             sys.stderr.write('%s\n' % (e.message,))
             continue
 
-        if merge:
-            if options.log:
-                subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
+        if options.abbrev is not None:
+            msg = rev_parse(merge, abbrev=options.abbrev)
+        else:
+            msg = merge
+        sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
 
-            if options.diff:
-                subprocess.check_call(['git', '--no-pager', 'show', merge])
+        if options.log:
+            subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
 
-            if options.visualize:
-                subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])
+        if options.diff:
+            subprocess.check_call(['git', '--no-pager', 'show', merge])
+
+        if options.visualize:
+            subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])
 
 
 main(sys.argv[1:])

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -233,6 +233,48 @@ def rev_list(*args):
         raise Failure('git rev-list %s failed' % (' '.join(args),))
 
 
+def rev_list_with_parents(*args):
+    cmd = ['git', 'log', '--format=%H %P'] + list(args) + ['--']
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    for line in process.stdout:
+        words = _decode_output(line).strip().split()
+        yield (words[0], words[1:])
+
+    retcode = process.wait()
+    if retcode:
+        raise Failure('command "%s" failed' % (' '.join(cmd),))
+
+
+class CommitGraph:
+    def __init__(self, *args):
+        self.commits = dict(rev_list_with_parents(*args))
+
+    def __contains__(self, commit):
+        return commit in self.commits
+
+    def __getitem__(self, commit):
+        return self.commits[commit]
+
+    def first_parent_path(self, commit):
+        """Iterate over the commits in the first-parent ancestry of commit.
+
+        Iterate over the commits that are within this CommitGraph that
+        are also in the first-parent ancestry of the specified commit.
+        commit must be a full 40-character SHA-1.
+
+        """
+
+        while True:
+            try:
+                parents = self[commit]
+            except KeyError:
+                return
+            yield commit
+            if not parents:
+                return
+            commit = parents[0]
+
+
 FORMAT = '%(refname)-38s %(msg)s\n'
 
 def find_merge(commit, branch, abbrev):
@@ -247,27 +289,27 @@ def find_merge(commit, branch, abbrev):
         sys.stdout.write(FORMAT % dict(refname=branch, msg='Is not a valid commit!'))
         return None
 
-    branch_commits = set(
-        rev_list('--first-parent', branch_sha1, '--not', '%s^@' % (commit,))
-        )
+    commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit, branch_sha1))
+    branch_commits = list(commit_graph.first_parent_path(branch_sha1))
 
-    if commit in branch_commits:
+    if not branch_commits:
+        sys.stdout.write(FORMAT % dict(refname=branch, msg='Does not contain commit.'))
+        return None
+
+    # The last entry in branch_commits is the one that merged in
+    # commit.
+    last = branch_commits[-1]
+    parents = commit_graph[last]
+
+    if parents[0] == commit:
         sys.stdout.write(FORMAT % dict(refname=branch, msg='Commit is directly on this branch.'))
         return None
 
-    last = None
-    for commit in rev_list('--ancestry-path', '%s..%s' % (commit, branch_sha1,)):
-        if commit in branch_commits:
-            last = commit
-
-    if not last:
-        sys.stdout.write(FORMAT % dict(refname=branch, msg='Does not contain commit.'))
+    if abbrev is not None:
+        msg = rev_parse(last, abbrev=abbrev)
     else:
-        if abbrev is not None:
-            msg = rev_parse(last, abbrev=abbrev)
-        else:
-            msg = last
-        sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
+        msg = last
+    sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
 
     return last
 

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -50,6 +50,9 @@ Examples:
   git when-merged 0a1b -n releases         # Use whenmerged.releases.pattern
   git when-merged 0a1b -s                  # Use whenmerged.default.pattern
 
+  git when-merged 0a1b -r feature-1        # If merged indirectly, show all
+                                           # merges involved.
+
   git when-merged 0a1b -l feature-1        # Show log for the merge commit
   git when-merged 0a1b -d feature-1        # Show diff for the merge commit
   git when-merged 0a1b -v feature-1        # Display merge commit in gitk
@@ -292,6 +295,12 @@ class DirectlyOnBranchError(MergeNotFoundError):
     msg = 'Commit is directly on this branch.'
 
 
+class MergedViaMultipleParentsError(MergeNotFoundError):
+    def __init__(self, refname, parents):
+        MergeNotFoundError.__init__(self, refname)
+        self.msg = 'Merged via multiple parents: %s' % (' '.join(parents),)
+
+
 def find_merge(commit, branch):
     """Return the SHA1 of the commit that merged commit into branch.
 
@@ -304,20 +313,38 @@ def find_merge(commit, branch):
         raise InvalidCommitError(branch)
 
     commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit, branch_sha1))
-    branch_commits = list(commit_graph.first_parent_path(branch_sha1))
 
-    if not branch_commits:
-        raise DoesNotContainCommitError(branch)
+    while True:
+        branch_commits = list(commit_graph.first_parent_path(branch_sha1))
 
-    # The last entry in branch_commits is the one that merged in
-    # commit.
-    last = branch_commits[-1]
-    parents = commit_graph[last]
+        if not branch_commits:
+            raise DoesNotContainCommitError(branch)
 
-    if parents[0] == commit:
-        raise DirectlyOnBranchError(branch)
+        # The last entry in branch_commits is the one that merged in
+        # commit.
+        last = branch_commits[-1]
+        parents = commit_graph[last]
 
-    return last
+        if parents[0] == commit:
+            raise DirectlyOnBranchError(branch)
+
+        yield last
+
+        if commit in parents:
+            # The commit was merged in directly:
+            return
+
+        # Find which parent(s) merged in the commit:
+        parents = [
+            parent
+            for parent in parents
+            if parent in commit_graph
+            ]
+        assert(parents)
+        if len(parents) > 1:
+            raise MergedViaMultipleParentsError(branch, parents)
+
+        [branch_sha1] = parents
 
 
 class Parser(optparse.OptionParser):
@@ -400,6 +427,11 @@ def main(args):
         help='Shorthand for "--name=default".',
         )
     parser.add_option(
+        '--recursive', '-r',
+        action='store_true',
+        help='Follow merges back recursively.',
+        )
+    parser.add_option(
         '--abbrev', metavar='N',
         action='store', type='int', default=default_abbrev,
         help=(
@@ -476,29 +508,45 @@ def main(args):
         branches.add(get_full_name('HEAD'))
 
     for branch in sorted(branches):
+        first = True
         try:
-            merge = find_merge(commit, branch)
+            for merge in find_merge(commit, branch):
+                if options.abbrev is not None:
+                    msg = rev_parse(merge, abbrev=options.abbrev)
+                else:
+                    msg = merge
+
+                if first:
+                    sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
+                else:
+                    sys.stdout.write(FORMAT % dict(refname='', msg='via %s' % (msg,)))
+
+                if options.log:
+                    subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
+
+                if options.diff:
+                    subprocess.check_call(['git', '--no-pager', 'show', merge])
+
+                if options.visualize:
+                    subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])
+
+                if options.recursive:
+                    first = False
+                else:
+                    break
+
+        except DirectlyOnBranchError as e:
+            if first:
+                sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+        except MergedViaMultipleParentsError as e:
+            if first:
+                sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+            else:
+                sys.stdout.write(FORMAT % dict(refname='', msg=e.msg))
         except MergeNotFoundError as e:
             sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
-            continue
         except Failure as e:
             sys.stderr.write('%s\n' % (e.message,))
-            continue
-
-        if options.abbrev is not None:
-            msg = rev_parse(merge, abbrev=options.abbrev)
-        else:
-            msg = merge
-        sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
-
-        if options.log:
-            subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
-
-        if options.diff:
-            subprocess.check_call(['git', '--no-pager', 'show', merge])
-
-        if options.visualize:
-            subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])
 
 
 main(sys.argv[1:])


### PR DESCRIPTION
Sometimes a commit finds its way into `master` via a series of merges. Add a `--recursive`/`-r` option, which shows all of the merges involved.
