### PR TITLE
Fix handling of tags

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -284,7 +284,7 @@ def find_merge(commit, branch, abbrev):
     subsequent parents of a merge commit."""
 
     try:
-        branch_sha1 = rev_parse(branch)
+        branch_sha1 = rev_parse('%s^{commit}' % (branch,))
     except Failure as e:
         sys.stdout.write(FORMAT % dict(refname=branch, msg='Is not a valid commit!'))
         return None


### PR DESCRIPTION
If the "branch" is actually a tag, we need to resolve it to the commit that it points at before proceeding.
