### PR TITLE
Also parse COMMIT argument into a commit

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -468,7 +468,7 @@ def main(args):
     commit = args.pop(0)
     # Convert commit into a SHA1:
     try:
-        commit = rev_parse(commit)
+        commit = rev_parse('%s^{commit}' % (commit,))
     except Failure as e:
         sys.exit(e.message)
 


### PR DESCRIPTION
If the COMMIT argument was a tag, the SHA-1 of the tag object was being sought in the `rev-parse` output. Instead, parse it into a commit before proceeding. This fixes invocations like

    $ git when-merged v1.0.0 master
