### PR TITLE
Add new output modes `--show-commit` and `--show-branch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ Options:
                         whenmerged.<name>.pattern below under CONFIGURATION).
   -s, --default         Shorthand for "--name=default".
   -r, --recursive       Follow merges back recursively.
-  --abbrev=N            Abbreviate commit SHA1s to the specified number of
+  --abbrev=N            Abbreviate commit SHA-1s to the specified number of
                         characters (or more if needed to avoid ambiguity).
                         See also whenmerged.abbrev below under CONFIGURATION.
-  --no-abbrev           Do not abbreviate commit SHA1s.
+  --no-abbrev           Do not abbreviate commit SHA-1s.
   -l, --log             Show the log for the merge commit.
   -d, --diff            Show the diff for the merge commit.
   -v, --visualize       Visualize the merge commit using gitk.
@@ -116,7 +116,7 @@ Configuration:
                   '^refs/remotes/origin/release\-\d+\.\d+$'
 
   whenmerged.abbrev
-      If this value is set to a positive integer, then Git SHA1s are
+      If this value is set to a positive integer, then Git SHA-1s are
       abbreviated to this number of characters (or longer if needed to
       avoid ambiguity).  This value can be overridden using --abbrev=N
       or --no-abbrev.

--- a/README.md
+++ b/README.md
@@ -76,13 +76,23 @@ optional arguments:
   --show-commit, -c     Display only the SHA-1 of the merge commit. Exit with
                         a nonzero exit code if the commit was not merged via a
                         merge commit.
+  --show-branch, -b     Display the range of commits that were merged at the
+                        same time as the specified commit. Exit with a nonzero
+                        exit code if the commit was not merged via a merge
+                        commit. This option also affects the behavior of --log
+                        and --visualize.
   --abbrev N            Abbreviate commit SHA-1s to the specified number of
                         characters (or more if needed to avoid ambiguity). See
                         also whenmerged.abbrev below under CONFIGURATION.
   --no-abbrev           Do not abbreviate commit SHA-1s.
-  --log, -l             Show the log for the merge commit.
+  --log, -l             Show the log for the merge commit. When used with
+                        "--show-branch/-b", show the log for all of the
+                        commits that were merged at the same time as the
+                        specified commit.
   --diff, -d            Show the diff for the merge commit.
-  --visualize, -v       Visualize the merge commit using gitk.
+  --visualize, -v       Visualize the merge commit using gitk. When used with
+                        "--show-branch/-b", only show the branch(es) that were
+                        merged at the same time as the specified commit.
 
 Examples:
   git when-merged 0a1b                     # Find merge into current branch

--- a/README.md
+++ b/README.md
@@ -52,36 +52,34 @@ $ brew install git-when-merged
 Find the merge commit that brought `COMMIT` into the specified `BRANCH`(es). Specifically, look for the oldest commit on the first-parent history of each `BRANCH` that contains the `COMMIT` as an ancestor.
 
 ```
-Options:
+positional arguments:
+  commit                The commit whose destiny you would like to determine.
+  branch                The destination branch(es) into which <commit> might
+                        have been merged. (Actually, BRANCH can be an
+                        arbitrary commit, specified in any way that is
+                        understood by git-rev-parse(1).) If neither <branch>
+                        nor --pattern/-p nor --default/-s is specified, then
+                        HEAD is used.
+
+optional arguments:
   -h, --help            show this help message and exit
-  -p PATTERN, --pattern=PATTERN
+  --pattern PATTERN, -p PATTERN
                         Show when COMMIT was merged to the references matching
-                        the specified regexp.  If the regexp has parentheses
+                        the specified regexp. If the regexp has parentheses
                         for grouping, then display in the output the part of
                         the reference name matching the first group.
-  -n NAME, --name=NAME  Show when COMMIT was merged to the references matching
+  --name NAME, -n NAME  Show when COMMIT was merged to the references matching
                         the configured pattern(s) with the given name (see
                         whenmerged.<name>.pattern below under CONFIGURATION).
-  -s, --default         Shorthand for "--name=default".
-  -r, --recursive       Follow merges back recursively.
-  --abbrev=N            Abbreviate commit SHA-1s to the specified number of
-                        characters (or more if needed to avoid ambiguity).
-                        See also whenmerged.abbrev below under CONFIGURATION.
+  --default, -s         Shorthand for "--name=default".
+  --recursive, -r       Follow merges back recursively.
+  --abbrev N            Abbreviate commit SHA-1s to the specified number of
+                        characters (or more if needed to avoid ambiguity). See
+                        also whenmerged.abbrev below under CONFIGURATION.
   --no-abbrev           Do not abbreviate commit SHA-1s.
-  -l, --log             Show the log for the merge commit.
-  -d, --diff            Show the diff for the merge commit.
-  -v, --visualize       Visualize the merge commit using gitk.
-
-  COMMIT
-      a commit whose destiny you would like to determine (this
-      argument is required)
-
-  BRANCH...
-      the destination branches into which <commit> might have been
-      merged.  (Actually, BRANCH can be an arbitrary commit, specified
-      in any way that is understood by git-rev-parse(1).) If neither
-      <branch> nor -p/--pattern nor -s/--default is specified, then
-      HEAD is used
+  --log, -l             Show the log for the merge commit.
+  --diff, -d            Show the diff for the merge commit.
+  --visualize, -v       Visualize the merge commit using gitk.
 
 Examples:
   git when-merged 0a1b                     # Find merge into current branch

--- a/README.md
+++ b/README.md
@@ -95,36 +95,38 @@ optional arguments:
                         merged at the same time as the specified commit.
 
 Examples:
-  git when-merged 0a1b                     # Find merge into current branch
-  git when-merged 0a1b feature-1 feature-2 # Find merge into given branches
-  git when-merged 0a1b -p feature-[0-9]+   # Specify branches by regex
-  git when-merged 0a1b -n releases         # Use whenmerged.releases.pattern
-  git when-merged 0a1b -s                  # Use whenmerged.default.pattern
+  git when-merged 0a1b                   # Find the merge commit that brought
+                                         # commit 0a1b into the current branch
+  git when-merged 0a1b v1.10 v1.11       # Find merge into given tags/branches
+  git when-merged 0a1b -p feature-[0-9]+ # Specify tags/branches by regex
+  git when-merged 0a1b -n releases       # Use whenmerged.releases.pattern
+  git when-merged 0a1b -s                # Use whenmerged.default.pattern
 
-  git when-merged 0a1b -r feature-1        # If merged indirectly, show all
-                                           # merges involved.
-
-  git when-merged 0a1b -l feature-1        # Show log for the merge commit
-  git when-merged 0a1b -d feature-1        # Show diff for the merge commit
-  git when-merged 0a1b -v feature-1        # Display merge commit in gitk
+  git when-merged -r 0a1b                # If the commit was merged indirectly,
+                                         # show each intermediate merge.
+  git when-merged -l 0a1b                # Show the log for the merge commit
+  git when-merged -lb 0a1b               # Show log for the whole merged branch
+  git when-merged -v 0a1b                # Visualize the merge commit in gitk
+  git when-merged -vb 0a1b               # Visualize the whole merged branch
+  git when-merged -d 0a1b                # Show the diff for the merge commit
+  git when-merged -c 0a1b                # Print only the merge's SHA-1
 
 Configuration:
   whenmerged.<name>.pattern
       Regular expressions that match reference names for the pattern
       called <name>.  A regexp is sought in the full reference name,
-      in the form "refs/heads/master".  This option can be
-      multivalued, in which case references matching any of the
-      patterns are considered.  Typically you will use pattern(s) that
-      match master and/or significant release branches, or perhaps
-      their remote-tracking equivalents.  For example,
+      in the form "refs/heads/master".  This option can be multivalued, in
+      which case references matching any of the patterns are considered.
+      Typically the pattern will be chosen to match master and/or significant
+      release branches or tags, or perhaps their remote-tracking equivalents.
+      For example,
 
-          git config whenmerged.default.pattern \
-                  '^refs/heads/master$'
+          git config whenmerged.default.pattern '^refs/heads/master$'
+          git config --add whenmerged.default.pattern '^refs/heads/maint$'
 
       or
 
-          git config whenmerged.releases.pattern \
-                  '^refs/remotes/origin/release\-\d+\.\d+$'
+          git config whenmerged.releases.pattern '^refs/tags/release-'
 
   whenmerged.abbrev
       If this value is set to a positive integer, then Git SHA-1s are

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ optional arguments:
                         whenmerged.<name>.pattern below under CONFIGURATION).
   --default, -s         Shorthand for "--name=default".
   --recursive, -r       Follow merges back recursively.
+  --show-commit, -c     Display only the SHA-1 of the merge commit. Exit with
+                        a nonzero exit code if the commit was not merged via a
+                        merge commit.
   --abbrev N            Abbreviate commit SHA-1s to the specified number of
                         characters (or more if needed to avoid ambiguity). See
                         also whenmerged.abbrev below under CONFIGURATION.

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -33,36 +33,38 @@ USAGE = r"""git when-merged [OPTIONS] COMMIT [BRANCH...]
 
 EPILOG = r"""
 Examples:
-  git when-merged 0a1b                     # Find merge into current branch
-  git when-merged 0a1b feature-1 feature-2 # Find merge into given branches
-  git when-merged 0a1b -p feature-[0-9]+   # Specify branches by regex
-  git when-merged 0a1b -n releases         # Use whenmerged.releases.pattern
-  git when-merged 0a1b -s                  # Use whenmerged.default.pattern
+  git when-merged 0a1b                   # Find the merge commit that brought
+                                         # commit 0a1b into the current branch
+  git when-merged 0a1b v1.10 v1.11       # Find merge into given tags/branches
+  git when-merged 0a1b -p feature-[0-9]+ # Specify tags/branches by regex
+  git when-merged 0a1b -n releases       # Use whenmerged.releases.pattern
+  git when-merged 0a1b -s                # Use whenmerged.default.pattern
 
-  git when-merged 0a1b -r feature-1        # If merged indirectly, show all
-                                           # merges involved.
-
-  git when-merged 0a1b -l feature-1        # Show log for the merge commit
-  git when-merged 0a1b -d feature-1        # Show diff for the merge commit
-  git when-merged 0a1b -v feature-1        # Display merge commit in gitk
+  git when-merged -r 0a1b                # If the commit was merged indirectly,
+                                         # show each intermediate merge.
+  git when-merged -l 0a1b                # Show the log for the merge commit
+  git when-merged -lb 0a1b               # Show log for the whole merged branch
+  git when-merged -v 0a1b                # Visualize the merge commit in gitk
+  git when-merged -vb 0a1b               # Visualize the whole merged branch
+  git when-merged -d 0a1b                # Show the diff for the merge commit
+  git when-merged -c 0a1b                # Print only the merge's SHA-1
 
 Configuration:
   whenmerged.<name>.pattern
       Regular expressions that match reference names for the pattern
       called <name>.  A regexp is sought in the full reference name,
-      in the form "refs/heads/master".  This option can be
-      multivalued, in which case references matching any of the
-      patterns are considered.  Typically you will use pattern(s) that
-      match master and/or significant release branches, or perhaps
-      their remote-tracking equivalents.  For example,
+      in the form "refs/heads/master".  This option can be multivalued, in
+      which case references matching any of the patterns are considered.
+      Typically the pattern will be chosen to match master and/or significant
+      release branches or tags, or perhaps their remote-tracking equivalents.
+      For example,
 
-          git config whenmerged.default.pattern \
-                  '^refs/heads/master$'
+          git config whenmerged.default.pattern '^refs/heads/master$'
+          git config --add whenmerged.default.pattern '^refs/heads/maint$'
 
       or
 
-          git config whenmerged.releases.pattern \
-                  '^refs/remotes/origin/release\-\d+\.\d+$'
+          git config whenmerged.releases.pattern '^refs/tags/release-'
 
   whenmerged.abbrev
       If this value is set to a positive integer, then Git SHA-1s are
@@ -70,7 +72,7 @@ Configuration:
       avoid ambiguity).  This value can be overridden using --abbrev=N
       or --no-abbrev.
 
-Based on:
+Originally based on:
   http://stackoverflow.com/questions/8475448/find-merge-commit-which-include-a-specific-commit
 """
 

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -367,6 +367,7 @@ FIRST_FORMAT = '%(refname)-38s %(sha1)s'
 OTHER_FORMAT = FIRST_FORMAT % dict(refname='', sha1='via %(sha1)s')
 
 COMMIT_FORMAT = '%(sha1)s'
+BRANCH_FORMAT = '%(sha1)s^1..%(sha1)s'
 
 WARN_FORMAT = '%(refname)-38s %(msg)s'
 
@@ -416,12 +417,24 @@ def main(args):
         action='store_true',
         help='Follow merges back recursively.',
         )
-    parser.add_argument(
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
         '--show-commit', '-c', action='store_true',
         help=(
             'Display only the SHA-1 of the merge commit. '
             'Exit with a nonzero exit code if the commit was not merged '
             'via a merge commit.'
+            ),
+        )
+    group.add_argument(
+        '--show-branch', '-b', action='store_true',
+        help=(
+            'Display the range of commits that were merged '
+            'at the same time as the specified commit. '
+            'Exit with a nonzero exit code if the commit was not merged '
+            'via a merge commit. '
+            'This option also affects the behavior of --log and '
+            '--visualize.'
             ),
         )
     parser.add_argument(
@@ -439,7 +452,12 @@ def main(args):
         )
     parser.add_argument(
         '--log', '-l', action='store_true', default=False,
-        help='Show the log for the merge commit.',
+        help=(
+            'Show the log for the merge commit. '
+            'When used with "--show-branch/-b", show the log for all of '
+            'the commits that were merged at the same time as the specified '
+            'commit.'
+            ),
         )
     parser.add_argument(
         '--diff', '-d', action='store_true', default=False,
@@ -447,7 +465,11 @@ def main(args):
         )
     parser.add_argument(
         '--visualize', '-v', action='store_true', default=False,
-        help='Visualize the merge commit using gitk.',
+        help=(
+            'Visualize the merge commit using gitk. '
+            'When used with "--show-branch/-b", only show the branch(es) '
+            'that were merged at the same time as the specified commit.'
+            ),
         )
     parser.add_argument(
         'commit',
@@ -471,6 +493,9 @@ def main(args):
 
     if options.show_commit:
         first_format = other_format = COMMIT_FORMAT
+        warn = sys.exit
+    elif options.show_branch:
+        first_format = other_format = BRANCH_FORMAT
         warn = sys.exit
     else:
         first_format = FIRST_FORMAT
@@ -533,13 +558,28 @@ def main(args):
                 sys.stdout.write(format % dict(refname=branch, sha1=sha1) + '\n')
 
                 if options.log:
-                    subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', sha1])
+                    cmd = ['git', '--no-pager', 'log']
+                    if options.show_branch:
+                        cmd += ['--topo-order', '%s^1..%s' % (sha1, sha1)]
+                    else:
+                        cmd += ['--no-walk', sha1]
+                    subprocess.check_call(cmd)
 
                 if options.diff:
-                    subprocess.check_call(['git', '--no-pager', 'show', sha1])
+                    cmd = ['git', '--no-pager', 'diff', '%s^1..%s' % (sha1, sha1)]
+                    subprocess.check_call(cmd)
 
                 if options.visualize:
-                    subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (sha1,)])
+                    cmd = ['gitk']
+
+                    if options.show_branch:
+                        cmd += ['%s^1..%s' % (sha1, sha1)]
+                        cmd += ['--select-commit=%s' % (commit,)]
+                    else:
+                        cmd += ['--all']
+                        cmd += ['--select-commit=%s' % (sha1,)]
+
+                    subprocess.check_call(cmd)
 
                 if options.recursive:
                     first = False

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -32,17 +32,6 @@ USAGE = r"""git when-merged [OPTIONS] COMMIT [BRANCH...]
 """
 
 EPILOG = r"""
-  COMMIT
-      a commit whose destiny you would like to determine (this
-      argument is required)
-
-  BRANCH...
-      the destination branches into which <commit> might have been
-      merged.  (Actually, BRANCH can be an arbitrary commit, specified
-      in any way that is understood by git-rev-parse(1).) If neither
-      <branch> nor -p/--pattern nor -s/--default is specified, then
-      HEAD is used
-
 Examples:
   git when-merged 0a1b                     # Find merge into current branch
   git when-merged 0a1b feature-1 feature-2 # Find merge into given branches
@@ -88,7 +77,7 @@ Based on:
 import sys
 import re
 import subprocess
-import optparse
+import argparse
 
 
 if not (0x02060000 <= sys.hexversion):
@@ -347,16 +336,6 @@ def find_merge(commit, branch):
         [branch_sha1] = parents
 
 
-class Parser(optparse.OptionParser):
-    """An OptionParser that doesn't reflow usage and epilog."""
-
-    def get_usage(self):
-        return self.usage
-
-    def format_epilog(self, formatter):
-        return self.epilog
-
-
 def get_full_name(branch):
     """Return the full name of the specified commit.
 
@@ -388,8 +367,9 @@ FORMAT = '%(refname)-38s %(msg)s\n'
 
 
 def main(args):
-    parser = Parser(
+    parser = argparse.ArgumentParser(
         prog='git when-merged',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
         usage=USAGE,
         epilog=EPILOG,
@@ -402,17 +382,17 @@ def main(args):
     except CalledProcessError:
         default_abbrev = None
 
-    parser.add_option(
+    parser.add_argument(
         '--pattern', '-p', metavar='PATTERN',
         action='append', dest='patterns', default=[],
         help=(
             'Show when COMMIT was merged to the references matching '
-            'the specified regexp.  If the regexp has parentheses for '
+            'the specified regexp. If the regexp has parentheses for '
             'grouping, then display in the output the part of the '
             'reference name matching the first group.'
             ),
         )
-    parser.add_option(
+    parser.add_argument(
         '--name', '-n', metavar='NAME',
         action='append', dest='names', default=[],
         help=(
@@ -421,54 +401,64 @@ def main(args):
             'whenmerged.<name>.pattern below under CONFIGURATION).'
             ),
         )
-    parser.add_option(
+    parser.add_argument(
         '--default', '-s',
         action='append_const', dest='names', const='default',
         help='Shorthand for "--name=default".',
         )
-    parser.add_option(
+    parser.add_argument(
         '--recursive', '-r',
         action='store_true',
         help='Follow merges back recursively.',
         )
-    parser.add_option(
+    parser.add_argument(
         '--abbrev', metavar='N',
-        action='store', type='int', default=default_abbrev,
+        action='store', type=int, default=default_abbrev,
         help=(
             'Abbreviate commit SHA-1s to the specified number of characters '
             '(or more if needed to avoid ambiguity).  '
             'See also whenmerged.abbrev below under CONFIGURATION.'
             ),
         )
-    parser.add_option(
+    parser.add_argument(
         '--no-abbrev', dest='abbrev', action='store_const', const=None,
         help='Do not abbreviate commit SHA-1s.',
         )
-    parser.add_option(
+    parser.add_argument(
         '--log', '-l', action='store_true', default=False,
         help='Show the log for the merge commit.',
         )
-    parser.add_option(
+    parser.add_argument(
         '--diff', '-d', action='store_true', default=False,
         help='Show the diff for the merge commit.',
         )
-    parser.add_option(
+    parser.add_argument(
         '--visualize', '-v', action='store_true', default=False,
         help='Visualize the merge commit using gitk.',
         )
+    parser.add_argument(
+        'commit',
+        help='The commit whose destiny you would like to determine.',
+        )
+    parser.add_argument(
+        'branch', nargs='*',
+        help=(
+            'The destination branch(es) into which <commit> might have been '
+            'merged.  (Actually, BRANCH can be an arbitrary commit, specified '
+            'in any way that is understood by git-rev-parse(1).) If neither '
+            '<branch> nor --pattern/-p nor --default/-s is specified, then '
+            'HEAD is used.'
+            ),
+        )
 
-    (options, args) = parser.parse_args(args)
-
-    if not args:
-        parser.error('You must specify a COMMIT argument')
+    options = parser.parse_args(args)
 
     if options.abbrev is not None and options.abbrev <= 0:
         options.abbrev = None
 
-    commit = args.pop(0)
     # Convert commit into a SHA-1:
     try:
-        commit = rev_parse('%s^{commit}' % (commit,))
+        commit = rev_parse('%s^{commit}' % (options.commit,))
     except Failure as e:
         sys.exit(e.message)
 
@@ -498,7 +488,7 @@ def main(args):
             if matches_any(refname, refpatterns)
             )
 
-    for branch in args:
+    for branch in options.branch:
         try:
             branches.add(get_full_name(branch))
         except Failure as e:

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -361,7 +361,7 @@ def get_full_name(branch):
 
     # branch was not a reference, so just verify that it is valid but
     # leave it in its original form:
-    rev_parse(branch)
+    rev_parse('%s^{commit}' % (branch,))
     return branch
 
 

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -366,6 +366,8 @@ def get_full_name(branch):
 FIRST_FORMAT = '%(refname)-38s %(sha1)s'
 OTHER_FORMAT = FIRST_FORMAT % dict(refname='', sha1='via %(sha1)s')
 
+COMMIT_FORMAT = '%(sha1)s'
+
 WARN_FORMAT = '%(refname)-38s %(msg)s'
 
 
@@ -415,6 +417,14 @@ def main(args):
         help='Follow merges back recursively.',
         )
     parser.add_argument(
+        '--show-commit', '-c', action='store_true',
+        help=(
+            'Display only the SHA-1 of the merge commit. '
+            'Exit with a nonzero exit code if the commit was not merged '
+            'via a merge commit.'
+            ),
+        )
+    parser.add_argument(
         '--abbrev', metavar='N',
         action='store', type=int, default=default_abbrev,
         help=(
@@ -458,6 +468,14 @@ def main(args):
 
     if options.abbrev is not None and options.abbrev <= 0:
         options.abbrev = None
+
+    if options.show_commit:
+        first_format = other_format = COMMIT_FORMAT
+        warn = sys.exit
+    else:
+        first_format = FIRST_FORMAT
+        other_format = OTHER_FORMAT
+        warn = lambda msg: sys.stdout.write(msg + '\n')
 
     # Convert commit into a SHA-1:
     try:
@@ -508,9 +526,9 @@ def main(args):
                     sha1 = rev_parse(sha1, abbrev=options.abbrev)
 
                 if first:
-                    format = FIRST_FORMAT
+                    format = first_format
                 else:
-                    format = OTHER_FORMAT
+                    format = other_format
 
                 sys.stdout.write(format % dict(refname=branch, sha1=sha1) + '\n')
 
@@ -530,16 +548,16 @@ def main(args):
 
         except DirectlyOnBranchError as e:
             if first:
-                sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
+                warn(WARN_FORMAT % dict(refname=e.refname, msg=e.msg))
         except MergedViaMultipleParentsError as e:
             if first:
-                sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
+                warn(WARN_FORMAT % dict(refname=e.refname, msg=e.msg))
             else:
-                sys.stdout.write(WARN_FORMAT % dict(refname='', msg=e.msg) + '\n')
+                warn(WARN_FORMAT % dict(refname='', msg=e.msg))
         except MergeNotFoundError as e:
-            sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
+            warn(WARN_FORMAT % dict(refname=e.refname, msg=e.msg))
         except Failure as e:
-            sys.stderr.write('%s' % (e.message,))
+            sys.exit('%s' % (e.message,))
 
 
 main(sys.argv[1:])

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -363,7 +363,10 @@ def get_full_name(branch):
     return branch
 
 
-FORMAT = '%(refname)-38s %(msg)s\n'
+FIRST_FORMAT = '%(refname)-38s %(sha1)s'
+OTHER_FORMAT = FIRST_FORMAT % dict(refname='', sha1='via %(sha1)s')
+
+WARN_FORMAT = '%(refname)-38s %(msg)s'
 
 
 def main(args):
@@ -500,25 +503,25 @@ def main(args):
     for branch in sorted(branches):
         first = True
         try:
-            for merge in find_merge(commit, branch):
+            for sha1 in find_merge(commit, branch):
                 if options.abbrev is not None:
-                    msg = rev_parse(merge, abbrev=options.abbrev)
-                else:
-                    msg = merge
+                    sha1 = rev_parse(sha1, abbrev=options.abbrev)
 
                 if first:
-                    sys.stdout.write(FORMAT % dict(refname=branch, msg=msg))
+                    format = FIRST_FORMAT
                 else:
-                    sys.stdout.write(FORMAT % dict(refname='', msg='via %s' % (msg,)))
+                    format = OTHER_FORMAT
+
+                sys.stdout.write(format % dict(refname=branch, sha1=sha1) + '\n')
 
                 if options.log:
-                    subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', merge])
+                    subprocess.check_call(['git', '--no-pager', 'log', '--no-walk', sha1])
 
                 if options.diff:
-                    subprocess.check_call(['git', '--no-pager', 'show', merge])
+                    subprocess.check_call(['git', '--no-pager', 'show', sha1])
 
                 if options.visualize:
-                    subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (merge,)])
+                    subprocess.check_call(['gitk', '--all', '--select-commit=%s' % (sha1,)])
 
                 if options.recursive:
                     first = False
@@ -527,16 +530,16 @@ def main(args):
 
         except DirectlyOnBranchError as e:
             if first:
-                sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+                sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
         except MergedViaMultipleParentsError as e:
             if first:
-                sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+                sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
             else:
-                sys.stdout.write(FORMAT % dict(refname='', msg=e.msg))
+                sys.stdout.write(WARN_FORMAT % dict(refname='', msg=e.msg) + '\n')
         except MergeNotFoundError as e:
-            sys.stdout.write(FORMAT % dict(refname=e.refname, msg=e.msg))
+            sys.stdout.write(WARN_FORMAT % dict(refname=e.refname, msg=e.msg) + '\n')
         except Failure as e:
-            sys.stderr.write('%s\n' % (e.message,))
+            sys.stderr.write('%s' % (e.message,))
 
 
 main(sys.argv[1:])

--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -76,7 +76,7 @@ Configuration:
                   '^refs/remotes/origin/release\-\d+\.\d+$'
 
   whenmerged.abbrev
-      If this value is set to a positive integer, then Git SHA1s are
+      If this value is set to a positive integer, then Git SHA-1s are
       abbreviated to this number of characters (or longer if needed to
       avoid ambiguity).  This value can be overridden using --abbrev=N
       or --no-abbrev.
@@ -302,7 +302,7 @@ class MergedViaMultipleParentsError(MergeNotFoundError):
 
 
 def find_merge(commit, branch):
-    """Return the SHA1 of the commit that merged commit into branch.
+    """Return the SHA-1 of the commit that merged commit into branch.
 
     It is assumed that content is always merged in via the second or
     subsequent parents of a merge commit."""
@@ -435,14 +435,14 @@ def main(args):
         '--abbrev', metavar='N',
         action='store', type='int', default=default_abbrev,
         help=(
-            'Abbreviate commit SHA1s to the specified number of characters '
+            'Abbreviate commit SHA-1s to the specified number of characters '
             '(or more if needed to avoid ambiguity).  '
             'See also whenmerged.abbrev below under CONFIGURATION.'
             ),
         )
     parser.add_option(
         '--no-abbrev', dest='abbrev', action='store_const', const=None,
-        help='Do not abbreviate commit SHA1s.',
+        help='Do not abbreviate commit SHA-1s.',
         )
     parser.add_option(
         '--log', '-l', action='store_true', default=False,
@@ -466,7 +466,7 @@ def main(args):
         options.abbrev = None
 
     commit = args.pop(0)
-    # Convert commit into a SHA1:
+    # Convert commit into a SHA-1:
     try:
         commit = rev_parse('%s^{commit}' % (commit,))
     except Failure as e:


### PR DESCRIPTION
`--show-commit` makes the output more suitable for consumption by scripts.

`--show-branch` does that too, but also changes `--log` and `--visualize` to show all of the commits that were merged along with the specified commit (i.e., the whole branch, in the usual case).

/cc @pclouds: is this approximately what you were hoping for? Feedback would be welcome before I merge this.
