### PR TITLE
Don't use now-removed Exception.message attribute

### DIFF
--- a/bin/git-when-merged
+++ b/bin/git-when-merged
@@ -159,7 +159,7 @@ def read_refpatterns(name):
             except re.error as e:
                 sys.stderr.write(
                     'Error compiling branch pattern %r; ignoring: %s\n'
-                    % (value, e.message,)
+                    % (value, e,)
                     )
     return retval
 
@@ -549,7 +549,7 @@ def main(args):
     try:
         commit = rev_parse('%s^{commit}' % (options.commit,))
     except Failure as e:
-        sys.exit(e.message)
+        sys.exit(str(e))
 
     refpatterns = []
 
@@ -559,14 +559,14 @@ def main(args):
         except re.error as e:
             sys.stderr.write(
                 'Error compiling pattern %r; ignoring: %s\n'
-                % (value, e.message,)
+                % (value, e,)
                 )
 
     for value in options.names:
         try:
             refpatterns.extend(read_refpatterns(value))
         except Failure as e:
-            sys.exit(e.message)
+            sys.exit(str(e))
 
     branches = set()
 
@@ -581,7 +581,7 @@ def main(args):
         try:
             branches.add(get_full_name(branch))
         except Failure as e:
-            sys.exit(e.message)
+            sys.exit(str(e))
 
     if not branches:
         branches.add(get_full_name('HEAD'))
@@ -641,7 +641,7 @@ def main(args):
         except MergeNotFoundError as e:
             warn(WARN_FORMAT % dict(refname=e.refname, msg=e.msg))
         except Failure as e:
-            sys.exit('%s' % (e.message,))
+            sys.exit('%s' % (e,))
 
 
 main(sys.argv[1:])


### PR DESCRIPTION
BaseException.message has been deprecated since Python 2.6 [0] and
does not exist in Python 3 (CPython's ebe3e16600).  As a result, the
user sees messages like

    $ git-when-merged not-valid
    [...]
    Traceback (most recent call last):
      File "bin/git-when-merged", line 550, in main
        commit = rev_parse('%s^{commit}' % (options.commit,))
      File "bin/git-when-merged", line 207, in rev_parse
        raise Failure('%r is not a valid commit!' % (arg,))
    __main__.Failure: 'not-valid^{commit}' is not a valid commit!

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "bin/git-when-merged", line 647, in <module>
        main(sys.argv[1:])
      File "bin/git-when-merged", line 552, in main
        sys.exit(e.message)
    AttributeError: 'Failure' object has no attribute 'message'

When the exception is used as a string formatting argument, simply
drop ".message".  Otherwise, obtain the message with str().

[0]: https://www.python.org/dev/peps/pep-0352/