### PR TITLE
Correctly handle the case when the commit is at the tip of the branch

### DIFF
--- a/src/git_when_merged.py
+++ b/src/git_when_merged.py
@@ -318,6 +318,9 @@ def find_merge(commit_sha1, branch):
     except Failure:
         raise InvalidCommitError(branch)
 
+    if branch_sha1 == commit_sha1:
+        raise DirectlyOnBranchError(branch)
+
     commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit_sha1, branch_sha1))
 
     while True:

--- a/src/git_when_merged.py
+++ b/src/git_when_merged.py
@@ -307,7 +307,7 @@ class MergedViaMultipleParentsError(MergeNotFoundError):
         self.msg = 'Merged via multiple parents: %s' % (' '.join(parents),)
 
 
-def find_merge(commit, branch):
+def find_merge(commit_sha1, branch):
     """Return the SHA-1 of the commit that merged commit into branch.
 
     It is assumed that content is always merged in via the second or
@@ -318,7 +318,7 @@ def find_merge(commit, branch):
     except Failure:
         raise InvalidCommitError(branch)
 
-    commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit, branch_sha1))
+    commit_graph = CommitGraph('--ancestry-path', '%s..%s' % (commit_sha1, branch_sha1))
 
     while True:
         branch_commits = list(commit_graph.first_parent_path(branch_sha1))
@@ -331,12 +331,12 @@ def find_merge(commit, branch):
         last = branch_commits[-1]
         parents = commit_graph[last]
 
-        if parents[0] == commit:
+        if parents[0] == commit_sha1:
             raise DirectlyOnBranchError(branch)
 
         yield last
 
-        if commit in parents:
+        if commit_sha1 in parents:
             # The commit was merged in directly:
             return
 
@@ -549,7 +549,7 @@ def main(args=None):
 
     # Convert commit into a SHA-1:
     try:
-        commit = rev_parse('%s^{commit}' % (options.commit,))
+        commit_sha1 = rev_parse('%s^{commit}' % (options.commit,))
     except Failure as e:
         sys.exit(str(e))
 
@@ -591,7 +591,7 @@ def main(args=None):
     for branch in sorted(branches):
         first = True
         try:
-            for sha1 in find_merge(commit, branch):
+            for sha1 in find_merge(commit_sha1, branch):
                 name = name_commit(sha1, options)
 
                 if first:
@@ -620,7 +620,7 @@ def main(args=None):
 
                     if options.show_branch:
                         cmd += ['%s^1..%s' % (sha1, sha1)]
-                        cmd += ['--select-commit=%s' % (commit,)]
+                        cmd += ['--select-commit=%s' % (commit_sha1,)]
                     else:
                         cmd += ['--all']
                         cmd += ['--select-commit=%s' % (sha1,)]


### PR DESCRIPTION
If the commit being sought is at the tip of the branch, then report it as "Commit is directly on this branch" rather than "Does not contain commit".

Fixes #23.

/cc @binrush
